### PR TITLE
fix: Complex time of impact would ignore later primitive pairs if one pair did not collide

### DIFF
--- a/src/algorithm/minkowski/gjk/mod.rs
+++ b/src/algorithm/minkowski/gjk/mod.rs
@@ -558,21 +558,20 @@ where
             for &(ref right_primitive, ref right_local_transform) in right.iter() {
                 let right_start_transform = right_transform.start.concat(right_local_transform);
                 let right_end_transform = right_transform.end.concat(right_local_transform);
-                match self.intersection_time_of_impact(
+                if let Some(mut contact) = self.intersection_time_of_impact(
                     left_primitive,
                     &left_start_transform..&left_end_transform,
                     right_primitive,
                     &right_start_transform..&right_end_transform,
                 ) {
-                    None => return None,
-                    Some(mut contact) => match *strategy {
+                    match *strategy {
                         CollisionOnly => {
                             contact.strategy = CollisionOnly;
                             return Some(contact);
                         }
                         FullResolution => contacts.push(contact),
-                    },
-                };
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #72.

cc @msiglreith

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/74)
<!-- Reviewable:end -->
