### PR TITLE
Expose `Variance2` and `Variance3`

### DIFF
--- a/src/algorithm/broad_phase/mod.rs
+++ b/src/algorithm/broad_phase/mod.rs
@@ -2,7 +2,9 @@
 
 pub use self::brute_force::BruteForce;
 pub use self::dbvt::DbvtBroadPhase;
-pub use self::sweep_prune::{SweepAndPrune, SweepAndPrune2, SweepAndPrune3, Variance};
+pub use self::sweep_prune::{
+    SweepAndPrune, SweepAndPrune2, SweepAndPrune3, Variance, Variance2, Variance3,
+};
 
 mod brute_force;
 mod sweep_prune;


### PR DESCRIPTION
These types are mentioned in the docs for [collision::algorithm::broad_phase::SweepAndPrune](https://docs.rs/collision/0.18.0/collision/algorithm/broad_phase/struct.SweepAndPrune.html), and they are required for constructing `SweepAndPrune`. The re-export list is quite long, and I wasn't sure what formatting to use, so I can change it if requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/98)
<!-- Reviewable:end -->
