### PR TITLE
Update documentation of SweepAndPrune to not mention private types

### DIFF
--- a/src/algorithm/broad_phase/sweep_prune.rs
+++ b/src/algorithm/broad_phase/sweep_prune.rs
@@ -26,8 +26,10 @@ pub type SweepAndPrune3<S, B> = SweepAndPrune<Variance3<S, B>>;
 ///
 /// # Type parameters:
 ///
-/// - `V`: Variance type used for computing what axis to use on the next iteration. Should be either
-///        `Variance2` or `Variance3`.
+/// - `V`: Variance type used for computing what axis to use on the next iteration.
+///        [SweepAndPrune2](type.SweepAndPrune2.html) and [SweepAndPrune3](type.SweepAndPrune3.html)
+///        provide a variance type for you, so they should be used if you do not have a custom type
+///        implementing [Variance](trait.Variance.html).
 pub struct SweepAndPrune<V> {
     sweep_axis: usize,
     variance: V,


### PR DESCRIPTION
It can be confusing to see a reference to a type and not be able to find it, so I think referring users to the type aliases is a good idea here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/99)
<!-- Reviewable:end -->
