### PR TITLE
Bumped num dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ keywords = ["gamedev", "cgmath", "collision"]
 name = "collision"
 
 [dependencies]
-num = "0.1"
+num = "0.2"
 rand = "0.4"
 approx = "0.1"
 cgmath = "0.16"
@@ -40,6 +40,8 @@ smallvec = "0.6.1"
 
 [target.'cfg(feature="serde")'.dependencies]
 cgmath = { version = "0.16", features = ["serde"] }
+num = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
 genmesh = "0.5"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "collision"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Brian Heylin",
         "Colin Sherratt",


### PR DESCRIPTION
The problem: ```num``` 0.1 had ```rustc_serialize``` dependency, which cant be compiled on wasm32-unknown-unknown.

```num``` 0.1  did not set ```default_features = false``` for its serde-related sub-dependencies, so enabling ```num/serde``` feature resulted ```rustc_serialize``` in the ```collision-rs``` dependencies. Switch to 0.2 was an easy fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/105)
<!-- Reviewable:end -->
