### PR TITLE
Upgraded collision to Rust2018 and synced with cgmath 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "collision"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Brian Heylin",
         "Colin Sherratt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Simon Rönnberg",
         "Pierre Krieger",
         "Tomasz Stachowiak",
-        "Zeke Foppa"
+        "Zeke Foppa",
+        "Thomas O'Dell"
 ]
 license = "Apache-2.0"
 description = "A collision extension to cgmath"
@@ -31,16 +32,15 @@ keywords = ["gamedev", "cgmath", "collision"]
 name = "collision"
 
 [dependencies]
-num = "0.2"
-rand = "0.4"
-approx = "0.1"
-cgmath = "0.16"
+rand = "0.6"
+approx = "0.3" # Only for the macros; for all other instances use the re-exported cgmath ones.
+cgmath = "0.17"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 bit-set = "0.5"
 smallvec = "0.6.1"
 
 [target.'cfg(feature="serde")'.dependencies]
-cgmath = { version = "0.16", features = ["serde"] }
+cgmath = { version = "0.17", features = ["serde"] }
 num = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
 ]
 license = "Apache-2.0"
 description = "A collision extension to cgmath"
+edition = "2018"
 
 documentation = "https://docs.rs/collision"
 homepage = "https://github.com/rustgd/collision-rs"

--- a/src/algorithm/broad_phase/brute_force.rs
+++ b/src/algorithm/broad_phase/brute_force.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 
 /// Broad phase collision detection brute force implementation.
 ///
@@ -44,7 +44,7 @@ mod tests {
     use cgmath::Point2;
 
     use super::*;
-    use Aabb2;
+    use crate::Aabb2;
 
     #[derive(Debug, Clone, PartialEq)]
     pub struct BroadCollisionInfo2 {

--- a/src/algorithm/broad_phase/dbvt.rs
+++ b/src/algorithm/broad_phase/dbvt.rs
@@ -3,8 +3,8 @@
 
 use std::cmp::Ordering;
 
-use dbvt::{DiscreteVisitor, DynamicBoundingVolumeTree, TreeValue};
-use prelude::*;
+use crate::dbvt::{DiscreteVisitor, DynamicBoundingVolumeTree, TreeValue};
+use crate::prelude::*;
 
 /// [`Dynamic Bounding Volume Tree`](../../dbvt/struct.DynamicBoundingVolumeTree.html) accelerated
 /// broad phase collision detection algorithm

--- a/src/algorithm/broad_phase/sweep_prune.rs
+++ b/src/algorithm/broad_phase/sweep_prune.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use num::NumCast;
 
 use self::variance::{Variance2, Variance3};
-use prelude::*;
+use crate::prelude::*;
 
 /// Broad phase sweep and prune algorithm for 2D, see
 /// [SweepAndPrune](struct.SweepAndPrune.html) for more information.
@@ -137,7 +137,7 @@ where
 mod variance {
     use std::marker;
 
-    use Bound;
+    use crate::Bound;
     use cgmath::{BaseFloat, Point2, Point3, Vector2, Vector3};
     use cgmath::prelude::*;
 
@@ -281,7 +281,7 @@ mod tests {
     use cgmath::Point2;
 
     use super::*;
-    use Aabb2;
+    use crate::Aabb2;
 
     #[derive(Debug, Clone, PartialEq)]
     pub struct BroadCollisionInfo2 {

--- a/src/algorithm/broad_phase/sweep_prune.rs
+++ b/src/algorithm/broad_phase/sweep_prune.rs
@@ -2,7 +2,7 @@ pub use self::variance::Variance;
 
 use std::cmp::Ordering;
 
-use num::NumCast;
+use cgmath::num_traits::NumCast;
 
 use self::variance::{Variance2, Variance3};
 use crate::prelude::*;

--- a/src/algorithm/minkowski/epa/epa2d.rs
+++ b/src/algorithm/minkowski/epa/epa2d.rs
@@ -5,9 +5,9 @@ use cgmath::prelude::*;
 use num::NumCast;
 
 use super::*;
-use {CollisionStrategy, Contact};
-use prelude::*;
-use primitive::util::triple_product;
+use crate::{CollisionStrategy, Contact};
+use crate::prelude::*;
+use crate::primitive::util::triple_product;
 
 /// EPA algorithm implementation for 2D. Only to be used in [`GJK`](struct.GJK.html).
 #[derive(Debug)]
@@ -159,8 +159,8 @@ mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
 
     use super::*;
-    use algorithm::minkowski::SupportPoint;
-    use primitive::*;
+    use crate::algorithm::minkowski::SupportPoint;
+    use crate::primitive::*;
 
     #[test]
     fn test_closest_edge_0() {

--- a/src/algorithm/minkowski/epa/epa2d.rs
+++ b/src/algorithm/minkowski/epa/epa2d.rs
@@ -2,7 +2,8 @@ use std::marker;
 
 use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
-use num::NumCast;
+use cgmath::num_traits::NumCast;
+use approx::assert_ulps_ne;
 
 use super::*;
 use crate::{CollisionStrategy, Contact};
@@ -157,6 +158,7 @@ where
 #[cfg(test)]
 mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use crate::algorithm::minkowski::SupportPoint;

--- a/src/algorithm/minkowski/epa/epa3d.rs
+++ b/src/algorithm/minkowski/epa/epa3d.rs
@@ -6,9 +6,9 @@ use num::NumCast;
 
 use super::*;
 use super::SupportPoint;
-use {CollisionStrategy, Contact};
-use prelude::*;
-use primitive::util::barycentric_vector;
+use crate::{CollisionStrategy, Contact};
+use crate::prelude::*;
+use crate::primitive::util::barycentric_vector;
 
 /// EPA algorithm implementation for 3D. Only to be used in [`GJK`](struct.GJK.html).
 #[derive(Debug)]
@@ -223,7 +223,7 @@ mod tests {
     use cgmath::{Decomposed, Quaternion, Rad, Vector3};
 
     use super::*;
-    use primitive::*;
+    use crate::primitive::*;
 
     #[test]
     fn test_remove_or_add_edge_added() {

--- a/src/algorithm/minkowski/epa/epa3d.rs
+++ b/src/algorithm/minkowski/epa/epa3d.rs
@@ -2,7 +2,7 @@ use std::marker;
 
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
-use num::NumCast;
+use cgmath::num_traits::NumCast;
 
 use super::*;
 use super::SupportPoint;
@@ -221,6 +221,7 @@ fn remove_or_add_edge(edges: &mut Vec<(usize, usize)>, edge: (usize, usize)) {
 #[cfg(test)]
 mod tests {
     use cgmath::{Decomposed, Quaternion, Rad, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use crate::primitive::*;

--- a/src/algorithm/minkowski/epa/mod.rs
+++ b/src/algorithm/minkowski/epa/mod.rs
@@ -9,8 +9,8 @@ mod epa3d;
 use cgmath::prelude::*;
 
 use super::SupportPoint;
-use Contact;
-use prelude::*;
+use crate::Contact;
+use crate::prelude::*;
 
 pub const EPA_TOLERANCE: f32 = 0.00001;
 pub const MAX_ITERATIONS: u32 = 100;

--- a/src/algorithm/minkowski/gjk/mod.rs
+++ b/src/algorithm/minkowski/gjk/mod.rs
@@ -11,9 +11,9 @@ use cgmath::prelude::*;
 use num::NumCast;
 
 use self::simplex::{Simplex, SimplexProcessor2, SimplexProcessor3};
-use {CollisionStrategy, Contact};
-use algorithm::minkowski::{EPA2, EPA3, SupportPoint, EPA};
-use prelude::*;
+use crate::{CollisionStrategy, Contact};
+use crate::algorithm::minkowski::{EPA2, EPA3, SupportPoint, EPA};
+use crate::prelude::*;
 
 mod simplex;
 
@@ -589,7 +589,7 @@ mod tests {
                  Vector2, Vector3};
 
     use super::*;
-    use primitive::*;
+    use crate::primitive::*;
 
     fn transform(x: f32, y: f32, angle: f32) -> Decomposed<Vector2<f32>, Basis2<f32>> {
         Decomposed {

--- a/src/algorithm/minkowski/gjk/mod.rs
+++ b/src/algorithm/minkowski/gjk/mod.rs
@@ -8,12 +8,13 @@ use std::ops::{Neg, Range};
 
 use cgmath::BaseFloat;
 use cgmath::prelude::*;
-use num::NumCast;
+use cgmath::num_traits::NumCast;
 
 use self::simplex::{Simplex, SimplexProcessor2, SimplexProcessor3};
 use crate::{CollisionStrategy, Contact};
 use crate::algorithm::minkowski::{EPA2, EPA3, SupportPoint, EPA};
 use crate::prelude::*;
+use approx::ulps_eq;
 
 mod simplex;
 
@@ -587,6 +588,7 @@ where
 mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Point3, Quaternion, Rad, Rotation2, Rotation3,
                  Vector2, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use crate::primitive::*;

--- a/src/algorithm/minkowski/gjk/simplex/mod.rs
+++ b/src/algorithm/minkowski/gjk/simplex/mod.rs
@@ -7,7 +7,7 @@ mod simplex3d;
 use cgmath::prelude::*;
 use smallvec::SmallVec;
 
-use algorithm::minkowski::SupportPoint;
+use crate::algorithm::minkowski::SupportPoint;
 
 pub type Simplex<P> = SmallVec<[SupportPoint<P>; 5]>;
 

--- a/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
@@ -5,7 +5,7 @@ use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
 
 use super::{Simplex, SimplexProcessor};
-use primitive::util::{get_closest_point_on_edge, triple_product};
+use crate::primitive::util::{get_closest_point_on_edge, triple_product};
 
 /// Simplex processor implementation for 2D. Only to be used in [`GJK`](struct.GJK.html).
 #[derive(Debug)]
@@ -99,7 +99,7 @@ mod tests {
     use cgmath::Vector2;
 
     use super::*;
-    use algorithm::minkowski::SupportPoint;
+    use crate::algorithm::minkowski::SupportPoint;
 
     #[test]
     fn test_check_origin_empty() {

--- a/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
@@ -3,6 +3,7 @@ use std::ops::Neg;
 
 use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
+use approx::ulps_eq;
 
 use super::{Simplex, SimplexProcessor};
 use crate::primitive::util::{get_closest_point_on_edge, triple_product};
@@ -100,6 +101,7 @@ mod tests {
 
     use super::*;
     use crate::algorithm::minkowski::SupportPoint;
+    use approx::assert_ulps_eq;
 
     #[test]
     fn test_check_origin_empty() {

--- a/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
@@ -6,7 +6,7 @@ use cgmath::prelude::*;
 use num::cast;
 
 use super::{Simplex, SimplexProcessor};
-use primitive::util::{barycentric_vector, get_closest_point_on_edge};
+use crate::primitive::util::{barycentric_vector, get_closest_point_on_edge};
 
 /// Simplex processor implementation for 3D. Only to be used in [`GJK`](struct.GJK.html).
 #[derive(Debug)]
@@ -136,7 +136,7 @@ fn get_closest_point_on_face<S>(
 where
     S: BaseFloat,
 {
-    use {Continuous, Plane, Ray3};
+    use crate::{Continuous, Plane, Ray3};
     let ap = Point3::from_vec(*a);
     let bp = Point3::from_vec(*b);
     let cp = Point3::from_vec(*c);
@@ -225,7 +225,7 @@ mod tests {
     use cgmath::{Point3, Vector3};
 
     use super::*;
-    use algorithm::minkowski::SupportPoint;
+    use crate::algorithm::minkowski::SupportPoint;
 
     #[test]
     fn test_check_side_outside_ab() {

--- a/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
@@ -3,7 +3,8 @@ use std::ops::Neg;
 
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
-use num::cast;
+use cgmath::num_traits::cast;
+use approx::ulps_eq;
 
 use super::{Simplex, SimplexProcessor};
 use crate::primitive::util::{barycentric_vector, get_closest_point_on_edge};
@@ -223,6 +224,7 @@ mod tests {
     use std::ops::Neg;
 
     use cgmath::{Point3, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use crate::algorithm::minkowski::SupportPoint;

--- a/src/algorithm/minkowski/mod.rs
+++ b/src/algorithm/minkowski/mod.rs
@@ -6,7 +6,7 @@ pub use self::gjk::{GJK2, GJK3, SimplexProcessor, GJK};
 use std::ops::{Neg, Sub};
 
 use cgmath::prelude::*;
-use prelude::*;
+use crate::prelude::*;
 
 mod epa;
 mod gjk;
@@ -80,7 +80,7 @@ mod tests {
     use cgmath::{Basis2, Decomposed, Rad, Rotation2, Vector2};
 
     use super::SupportPoint;
-    use primitive::*;
+    use crate::primitive::*;
 
     fn transform(x: f32, y: f32, angle: f32) -> Decomposed<Vector2<f32>, Basis2<f32>> {
         Decomposed {

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -5,8 +5,8 @@ use cgmath::BaseFloat;
 use cgmath::Matrix4;
 use std::{cmp, fmt};
 
-use frustum::Frustum;
-use plane::Plane;
+use crate::frustum::Frustum;
+use crate::plane::Plane;
 
 /// Spatial relation between two objects.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
@@ -23,7 +23,7 @@ pub enum Relation {
 /// Generic 3D bound.
 pub trait PlaneBound<S: BaseFloat>: fmt::Debug {
     /// Classify the spatial relation with a plane.
-    fn relate_plane(&self, Plane<S>) -> Relation;
+    fn relate_plane(&self, plane: Plane<S>) -> Relation;
     /// Classify the relation with a projection matrix.
     fn relate_clip_space(&self, projection: Matrix4<S>) -> Relation {
         let frustum = match Frustum::from_matrix4(projection) {

--- a/src/dbvt/mod.rs
+++ b/src/dbvt/mod.rs
@@ -98,7 +98,7 @@ use num::NumCast;
 use rand;
 use rand::Rng;
 
-use prelude::*;
+use crate::prelude::*;
 
 mod wrapped;
 mod visitor;

--- a/src/dbvt/mod.rs
+++ b/src/dbvt/mod.rs
@@ -94,7 +94,7 @@ pub use self::wrapped::TreeValueWrapped;
 use std::cmp::max;
 use std::fmt;
 
-use num::NumCast;
+use cgmath::num_traits::NumCast;
 use rand;
 use rand::Rng;
 

--- a/src/dbvt/util.rs
+++ b/src/dbvt/util.rs
@@ -8,8 +8,8 @@ use cgmath::BaseFloat;
 use cgmath::prelude::*;
 
 use super::{ContinuousVisitor, DynamicBoundingVolumeTree, TreeValue, Visitor};
-use Ray;
-use prelude::*;
+use crate::Ray;
+use crate::prelude::*;
 
 struct RayClosestVisitor<S, P, T>
 where

--- a/src/dbvt/visitor.rs
+++ b/src/dbvt/visitor.rs
@@ -7,8 +7,8 @@ use std::marker::PhantomData;
 use cgmath::BaseFloat;
 
 use super::{TreeValue, Visitor};
-use {Frustum, PlaneBound, Relation};
-use prelude::*;
+use crate::{Frustum, PlaneBound, Relation};
+use crate::prelude::*;
 
 /// Visitor for doing continuous intersection testing on the DBVT.
 ///

--- a/src/dbvt/wrapped.rs
+++ b/src/dbvt/wrapped.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use cgmath::{EuclideanSpace, Zero};
 
 use super::TreeValue;
-use {Bound, HasBound};
+use crate::{Bound, HasBound};
 
 /// Value together with bounding volume, for use with DBVT.
 #[derive(Debug, Clone)]

--- a/src/frustum.rs
+++ b/src/frustum.rs
@@ -1,7 +1,7 @@
 //! View frustum for visibility determination
 
-use Plane;
-use bound::*;
+use crate::Plane;
+use crate::bound::*;
 use cgmath::{Matrix, Matrix4};
 use cgmath::{Ortho, Perspective, PerspectiveFov};
 use cgmath::BaseFloat;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![deny(missing_docs, trivial_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+unused_qualifications)]
 
 //! Companion library to cgmath, dealing with collision detection centric data structures and
 //! algorithms.
@@ -24,6 +24,8 @@ extern crate rand;
 extern crate serde;
 #[cfg_attr(test, macro_use)]
 extern crate smallvec;
+
+
 
 // Re-exports
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,9 @@ unused_qualifications)]
 //! bounding volumes (AABB, OBB, Sphere etc), collision primitives and algorithms used for
 //! collision detection, distance computation etc.
 //!
-#[macro_use]
-extern crate approx;
 
 extern crate bit_set;
 extern crate cgmath;
-extern crate num;
 extern crate rand;
 
 #[cfg(feature = "serde")]

--- a/src/line.rs
+++ b/src/line.rs
@@ -7,8 +7,8 @@ use cgmath::{Point2, Point3};
 use cgmath::{Vector2, Vector3};
 use cgmath::prelude::*;
 
-use Ray2;
-use prelude::*;
+use crate::Ray2;
+use crate::prelude::*;
 
 /// A generic directed line segment from `origin` to `dest`.
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use cgmath::{ApproxEq, BaseFloat, Point3, Vector3, Vector4};
 use cgmath::prelude::*;
 
-use Ray3;
-use prelude::*;
+use crate::Ray3;
+use crate::prelude::*;
 
 /// A 3-dimensional plane formed from the equation: `A*x + B*y + C*z - D = 0`.
 ///

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 
-use cgmath::{ApproxEq, BaseFloat, Point3, Vector3, Vector4};
+use cgmath::{BaseFloat, Point3, Vector3, Vector4};
+use cgmath::{AbsDiffEq, RelativeEq, UlpsEq};
 use cgmath::prelude::*;
+use approx::{ulps_eq, ulps_ne};
 
 use crate::Ray3;
 use crate::prelude::*;
@@ -105,9 +107,10 @@ impl<S: BaseFloat> Plane<S> {
     }
 }
 
-impl<S> ApproxEq for Plane<S>
-where
-    S: BaseFloat,
+impl<S: AbsDiffEq> AbsDiffEq for Plane<S>
+    where
+        S::Epsilon: Copy,
+        S: BaseFloat,
 {
     type Epsilon = S::Epsilon;
 
@@ -117,19 +120,36 @@ where
     }
 
     #[inline]
+    fn abs_diff_eq(&self, other: &Self, epsilon: S::Epsilon) -> bool {
+        Vector3::abs_diff_eq(&self.n, &other.n, epsilon)
+            && S::abs_diff_eq(&self.d, &other.d, epsilon)
+    }
+}
+
+impl<S: RelativeEq> RelativeEq for Plane<S>
+    where
+        S::Epsilon: Copy,
+        S: BaseFloat,
+{
+    #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
-    }
-
-    #[inline]
-    fn default_max_ulps() -> u32 {
-        S::default_max_ulps()
     }
 
     #[inline]
     fn relative_eq(&self, other: &Self, epsilon: S::Epsilon, max_relative: S::Epsilon) -> bool {
         Vector3::relative_eq(&self.n, &other.n, epsilon, max_relative)
             && S::relative_eq(&self.d, &other.d, epsilon, max_relative)
+    }
+}
+impl<S: UlpsEq> UlpsEq for Plane<S>
+    where
+        S::Epsilon: Copy,
+        S: BaseFloat,
+{
+    #[inline]
+    fn default_max_ulps() -> u32 {
+        S::default_max_ulps()
     }
 
     #[inline]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 //! Prelude provides all the traits of the library in a convenient form
 
-pub use bound::{PlaneBound, Relation};
-pub use traits::*;
-pub use volume::{Aabb, MinMax};
+pub use crate::bound::{PlaneBound, Relation};
+pub use crate::traits::*;
+pub use crate::volume::{Aabb, MinMax};

--- a/src/primitive/capsule.rs
+++ b/src/primitive/capsule.rs
@@ -1,10 +1,10 @@
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Ray3};
-use prelude::*;
-use primitive::util::cylinder_ray_quadratic_solve;
-use volume::Sphere;
+use crate::{Aabb3, Ray3};
+use crate::prelude::*;
+use crate::primitive::util::cylinder_ray_quadratic_solve;
+use crate::volume::Sphere;
 
 /// Capsule primitive
 /// Capsule body is aligned with the Y axis, with local origin in the center of the capsule.

--- a/src/primitive/capsule.rs
+++ b/src/primitive/capsule.rs
@@ -202,6 +202,7 @@ mod tests {
     use std;
 
     use cgmath::{Decomposed, Quaternion, Rad, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
 

--- a/src/primitive/circle.rs
+++ b/src/primitive/circle.rs
@@ -3,8 +3,8 @@
 use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
 
-use {Aabb2, Ray2};
-use prelude::*;
+use crate::{Aabb2, Ray2};
+use crate::prelude::*;
 
 /// Circle primitive
 #[derive(Debug, Clone, PartialEq)]
@@ -91,9 +91,9 @@ where
 mod tests {
     use std;
 
-    use Ray2;
+    use crate::Ray2;
     use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
-    use prelude::*;
+    use crate::prelude::*;
 
     use super::*;
 

--- a/src/primitive/circle.rs
+++ b/src/primitive/circle.rs
@@ -94,6 +94,7 @@ mod tests {
     use crate::Ray2;
     use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
     use crate::prelude::*;
+    use approx::assert_ulps_eq;
 
     use super::*;
 

--- a/src/primitive/cuboid.rs
+++ b/src/primitive/cuboid.rs
@@ -213,6 +213,7 @@ where
 mod tests {
 
     use cgmath::{Decomposed, Point3, Quaternion, Rad, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use Ray3;

--- a/src/primitive/cuboid.rs
+++ b/src/primitive/cuboid.rs
@@ -1,10 +1,10 @@
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Ray3};
-use prelude::*;
-use primitive::util::get_max_point;
-use volume::Sphere;
+use crate::{Aabb3, Ray3};
+use crate::prelude::*;
+use crate::primitive::util::get_max_point;
+use crate::volume::Sphere;
 
 /// Cuboid primitive.
 ///

--- a/src/primitive/cylinder.rs
+++ b/src/primitive/cylinder.rs
@@ -1,10 +1,10 @@
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Ray3};
-use prelude::*;
-use primitive::util::cylinder_ray_quadratic_solve;
-use volume::Sphere;
+use crate::{Aabb3, Ray3};
+use crate::prelude::*;
+use crate::primitive::util::cylinder_ray_quadratic_solve;
+use crate::volume::Sphere;
 
 /// Cylinder primitive
 /// Cylinder body is aligned with the Y axis, with local origin in the center of the cylinders.

--- a/src/primitive/cylinder.rs
+++ b/src/primitive/cylinder.rs
@@ -232,6 +232,7 @@ mod tests {
     use std;
 
     use cgmath::{Decomposed, Quaternion, Rad, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
 

--- a/src/primitive/line.rs
+++ b/src/primitive/line.rs
@@ -1,8 +1,8 @@
 use cgmath::{BaseFloat, InnerSpace, Point2, Transform, Vector2};
 
-use Aabb2;
-use line::Line2;
-use traits::{ComputeBound, Primitive};
+use crate::Aabb2;
+use crate::line::Line2;
+use crate::traits::{ComputeBound, Primitive};
 
 impl<S> Primitive for Line2<S>
 where
@@ -37,9 +37,9 @@ where
 mod tests {
 
     use super::*;
-    use algorithm::minkowski::GJK2;
+    use crate::algorithm::minkowski::GJK2;
     use cgmath::{Basis2, Decomposed, Rad, Rotation2};
-    use primitive::Rectangle;
+    use crate::primitive::Rectangle;
 
     fn transform(x: f32, y: f32, angle: f32) -> Decomposed<Vector2<f32>, Basis2<f32>> {
         Decomposed {

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -31,7 +31,7 @@ pub(crate) mod util;
 
 use cgmath::{EuclideanSpace, Transform};
 
-use prelude::*;
+use crate::prelude::*;
 
 impl<B, P> HasBound for (P, B)
 where

--- a/src/primitive/particle.rs
+++ b/src/primitive/particle.rs
@@ -163,6 +163,7 @@ where
 mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Rad, Vector2};
     use cgmath::prelude::*;
+    use approx::assert_ulps_eq;
 
     use super::*;
     use crate::primitive::Circle;

--- a/src/primitive/particle.rs
+++ b/src/primitive/particle.rs
@@ -6,8 +6,8 @@ use std::ops::Range;
 use cgmath::{BaseFloat, Point2, Point3};
 use cgmath::prelude::*;
 
-use Ray;
-use prelude::*;
+use crate::Ray;
+use crate::prelude::*;
 
 /// Represents a particle in space.
 ///
@@ -165,7 +165,7 @@ mod tests {
     use cgmath::prelude::*;
 
     use super::*;
-    use primitive::Circle;
+    use crate::primitive::Circle;
 
     #[test]
     fn test_discrete() {

--- a/src/primitive/polygon.rs
+++ b/src/primitive/polygon.rs
@@ -3,9 +3,9 @@
 use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
 
-use {Aabb2, Line2, Ray2};
-use prelude::*;
-use primitive::util::{get_bound, get_max_point};
+use crate::{Aabb2, Line2, Ray2};
+use crate::prelude::*;
+use crate::primitive::util::{get_bound, get_max_point};
 
 /// Convex polygon primitive.
 ///

--- a/src/primitive/polygon.rs
+++ b/src/primitive/polygon.rs
@@ -196,6 +196,7 @@ where
 #[cfg(test)]
 mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Rad, Vector2};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use {Aabb2, Ray2};

--- a/src/primitive/polyhedron.rs
+++ b/src/primitive/polyhedron.rs
@@ -5,10 +5,10 @@ use bit_set::BitSet;
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Plane, Ray3};
-use prelude::*;
-use primitive::util::barycentric_point;
-use volume::Sphere;
+use crate::{Aabb3, Plane, Ray3};
+use crate::prelude::*;
+use crate::primitive::util::barycentric_point;
+use crate::volume::Sphere;
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -579,8 +579,8 @@ mod tests {
     use cgmath::prelude::*;
 
     use super::ConvexPolyhedron;
-    use {Aabb3, Ray3};
-    use prelude::*;
+    use crate::{Aabb3, Ray3};
+    use crate::prelude::*;
 
     #[test]
     fn test_polytope_half_edge() {

--- a/src/primitive/polyhedron.rs
+++ b/src/primitive/polyhedron.rs
@@ -577,6 +577,7 @@ mod tests {
 
     use cgmath::{Decomposed, Point3, Quaternion, Rad, Vector3};
     use cgmath::prelude::*;
+    use approx::assert_ulps_eq;
 
     use super::ConvexPolyhedron;
     use crate::{Aabb3, Ray3};

--- a/src/primitive/primitive2.rs
+++ b/src/primitive/primitive2.rs
@@ -3,9 +3,9 @@
 use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
 
-use {Aabb2, Line2, Ray2};
-use prelude::*;
-use primitive::{Circle, ConvexPolygon, Particle2, Rectangle, Square};
+use crate::{Aabb2, Line2, Ray2};
+use crate::prelude::*;
+use crate::primitive::{Circle, ConvexPolygon, Particle2, Rectangle, Square};
 
 /// Wrapper enum for 2D primitives, that also implements the `Primitive` trait, making it easier
 /// to use many different primitives in algorithms.

--- a/src/primitive/primitive3.rs
+++ b/src/primitive/primitive3.rs
@@ -3,9 +3,9 @@
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Ray3};
-use prelude::*;
-use primitive::{Capsule, ConvexPolyhedron, Cube, Cuboid, Cylinder, Particle3, Quad, Sphere};
+use crate::{Aabb3, Ray3};
+use crate::prelude::*;
+use crate::primitive::{Capsule, ConvexPolyhedron, Cube, Cuboid, Cylinder, Particle3, Quad, Sphere};
 
 /// Wrapper enum for 3D primitives, that also implements the `Primitive` trait, making it easier
 /// to use many different primitives in algorithms.
@@ -123,13 +123,13 @@ where
     }
 }
 
-impl<S> ComputeBound<::volume::Sphere<S>> for Primitive3<S>
+impl<S> ComputeBound<crate::volume::Sphere<S>> for Primitive3<S>
 where
     S: BaseFloat,
 {
-    fn compute_bound(&self) -> ::volume::Sphere<S> {
+    fn compute_bound(&self) -> crate::volume::Sphere<S> {
         match *self {
-            Primitive3::Particle(_) => ::volume::Sphere {
+            Primitive3::Particle(_) => crate::volume::Sphere {
                 center: Point3::origin(),
                 radius: S::zero(),
             },

--- a/src/primitive/quad.rs
+++ b/src/primitive/quad.rs
@@ -3,9 +3,9 @@
 use cgmath::{BaseFloat, Point3, Vector2, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Ray3, Sphere};
-use prelude::*;
-use primitive::util::get_max_point;
+use crate::{Aabb3, Ray3, Sphere};
+use crate::prelude::*;
+use crate::primitive::util::get_max_point;
 
 /// Rectangular plane primitive. Will lie on the xy plane when not transformed.
 ///
@@ -124,9 +124,9 @@ where
 mod tests {
 
     use super::*;
-    use algorithm::minkowski::GJK3;
+    use crate::algorithm::minkowski::GJK3;
     use cgmath::{Decomposed, Quaternion};
-    use primitive::Cuboid;
+    use crate::primitive::Cuboid;
 
     fn transform(x: f32, y: f32, z: f32) -> Decomposed<Vector3<f32>, Quaternion<f32>> {
         Decomposed {

--- a/src/primitive/rectangle.rs
+++ b/src/primitive/rectangle.rs
@@ -3,9 +3,9 @@
 use cgmath::{BaseFloat, Point2, Vector2};
 use cgmath::prelude::*;
 
-use {Aabb2, Ray2};
-use prelude::*;
-use primitive::util::get_max_point;
+use crate::{Aabb2, Ray2};
+use crate::prelude::*;
+use crate::primitive::util::get_max_point;
 
 /// Rectangle primitive.
 ///

--- a/src/primitive/rectangle.rs
+++ b/src/primitive/rectangle.rs
@@ -185,6 +185,7 @@ where
 #[cfg(test)]
 mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Rad, Vector2};
+    use approx::assert_ulps_eq;
 
     use super::*;
 

--- a/src/primitive/sphere.rs
+++ b/src/primitive/sphere.rs
@@ -1,8 +1,8 @@
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Ray3};
-use prelude::*;
+use crate::{Aabb3, Ray3};
+use crate::prelude::*;
 
 /// Sphere primitive
 #[derive(Debug, Clone, PartialEq)]
@@ -46,12 +46,12 @@ where
     }
 }
 
-impl<S> ComputeBound<::volume::Sphere<S>> for Sphere<S>
+impl<S> ComputeBound<crate::volume::Sphere<S>> for Sphere<S>
 where
     S: BaseFloat,
 {
-    fn compute_bound(&self) -> ::volume::Sphere<S> {
-        ::volume::Sphere {
+    fn compute_bound(&self) -> crate::volume::Sphere<S> {
+        crate::volume::Sphere {
             center: Point3::origin(),
             radius: self.radius,
         }

--- a/src/primitive/sphere.rs
+++ b/src/primitive/sphere.rs
@@ -102,6 +102,7 @@ mod tests {
     use std;
 
     use cgmath::{Decomposed, Point3, Quaternion, Rad, Rotation3, Vector3};
+    use approx::assert_ulps_eq;
 
     use super::*;
 

--- a/src/primitive/util.rs
+++ b/src/primitive/util.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Neg;
 
-use {Aabb, Ray3};
+use crate::{Aabb, Ray3};
 use cgmath::{BaseFloat, BaseNum, Vector2};
 use cgmath::prelude::*;
 use num::Float;
@@ -141,7 +141,7 @@ mod tests {
     use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
 
     use super::*;
-    use Aabb2;
+    use crate::Aabb2;
 
     #[test]
     fn test_get_bound() {

--- a/src/primitive/util.rs
+++ b/src/primitive/util.rs
@@ -6,7 +6,7 @@ use std::ops::Neg;
 use crate::{Aabb, Ray3};
 use cgmath::{BaseFloat, BaseNum, Vector2};
 use cgmath::prelude::*;
-use num::Float;
+use cgmath::num_traits::Float;
 
 pub(crate) fn get_max_point<'a, P: 'a, T, I>(vertices: I, direction: &P::Diff, transform: &T) -> P
 where
@@ -139,6 +139,7 @@ mod tests {
     use std;
 
     use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
+    use approx::assert_ulps_eq;
 
     use super::*;
     use crate::Aabb2;

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -7,7 +7,7 @@ use cgmath::{Point2, Point3};
 use cgmath::{Vector2, Vector3};
 use cgmath::prelude::*;
 
-use traits::{Continuous, ContinuousTransformed, Discrete, DiscreteTransformed};
+use crate::traits::{Continuous, ContinuousTransformed, Discrete, DiscreteTransformed};
 
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.

--- a/src/volume/aabb/aabb2.rs
+++ b/src/volume/aabb/aabb2.rs
@@ -7,8 +7,8 @@ use cgmath::{BaseFloat, BaseNum, Point2, Vector2};
 use cgmath::prelude::*;
 
 use super::{max, min};
-use {Line2, Ray2};
-use prelude::*;
+use crate::{Line2, Ray2};
+use crate::prelude::*;
 
 /// A two-dimensional AABB, aka a rectangle.
 #[derive(Copy, Clone, PartialEq)]

--- a/src/volume/aabb/aabb3.rs
+++ b/src/volume/aabb/aabb3.rs
@@ -7,8 +7,8 @@ use cgmath::{BaseFloat, BaseNum, Point3, Vector3};
 use cgmath::prelude::*;
 
 use super::{max, min};
-use {Line3, Plane, Ray3, Sphere};
-use prelude::*;
+use crate::{Line3, Plane, Ray3, Sphere};
+use crate::prelude::*;
 
 /// A three-dimensional AABB, aka a rectangular prism.
 #[derive(Copy, Clone, PartialEq)]

--- a/src/volume/aabb/mod.rs
+++ b/src/volume/aabb/mod.rs
@@ -13,7 +13,7 @@ use std::cmp::{Ordering, PartialOrd};
 use cgmath::{BaseNum, Point2, Point3};
 use cgmath::prelude::*;
 
-use traits::Bound;
+use crate::traits::Bound;
 
 mod aabb2;
 mod aabb3;

--- a/src/volume/sphere.rs
+++ b/src/volume/sphere.rs
@@ -3,8 +3,8 @@
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
 
-use {Aabb3, Line3, Plane, Ray3};
-use prelude::*;
+use crate::{Aabb3, Line3, Plane, Ray3};
+use crate::prelude::*;
 
 /// Bounding sphere.
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/tests/plane.rs
+++ b/tests/plane.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate approx;
 
 extern crate cgmath;

--- a/tests/sphere.rs
+++ b/tests/sphere.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate approx;
 
 extern crate cgmath;


### PR DESCRIPTION
This version is upgraded to Rust2018 (minimum changes necessary to compile) and uses cgmath 0.17. It also reduces some of the double-dependencies (e.g. uses traits re-exported from cgmath instead of importing them directly from the source library).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/109)
<!-- Reviewable:end -->
