### PR TITLE
Update most dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,16 +32,16 @@ keywords = ["gamedev", "cgmath", "collision"]
 name = "collision"
 
 [dependencies]
-rand = "0.6"
+rand = "0.8.4"
 approx = "0.4" # Only for the macros; for all other instances use the re-exported cgmath ones.
-cgmath = "0.18"
-serde = { version = "1.0", optional = true, features = ["derive"] }
-bit-set = "0.5"
-smallvec = "0.6.1"
+cgmath = "0.18.0"
+serde = { version = "1.0.126", optional = true, features = ["derive"] }
+bit-set = "0.5.2"
+smallvec = "1.6.1"
 
 [target.'cfg(feature="serde")'.dependencies]
-cgmath = { version = "0.18", features = ["serde"] }
-num = { version = "0.2", features = ["serde"] }
+cgmath = { version = "0.18.0", features = ["serde"] }
+num = { version = "0.4.0", features = ["serde"] }
 
 [dev-dependencies]
 genmesh = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,15 @@ name = "collision"
 
 [dependencies]
 rand = "0.6"
-approx = "0.3" # Only for the macros; for all other instances use the re-exported cgmath ones.
-cgmath = "0.17"
+approx = "0.4" # Only for the macros; for all other instances use the re-exported cgmath ones.
+cgmath = "0.18"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 bit-set = "0.5"
 smallvec = "0.6.1"
 
 [target.'cfg(feature="serde")'.dependencies]
-cgmath = { version = "0.17", features = ["serde"] }
+cgmath = { version = "0.18", features = ["serde"] }
 num = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
 genmesh = "0.5"
-

--- a/benches/dbvt.rs
+++ b/benches/dbvt.rs
@@ -48,7 +48,7 @@ fn benchmark_insert(b: &mut Bencher) {
     let mut tree = DynamicBoundingVolumeTree::<Value>::new();
     let mut i = 0;
     b.iter(|| {
-        let offset = rng.gen_range(0., 100.);
+        let offset = rng.gen_range(0.0..100.0);
         tree.insert(Value::new(
             i,
             aabb2(offset + 2., offset + 2., offset + 4., offset + 4.),
@@ -63,7 +63,7 @@ fn benchmark_do_refit(b: &mut Bencher) {
     let mut tree = DynamicBoundingVolumeTree::<Value>::new();
     let mut i = 0;
     b.iter(|| {
-        let offset = rng.gen_range(0., 100.);
+        let offset = rng.gen_range(0.0..100.0);
         tree.insert(Value::new(
             i,
             aabb2(offset + 2., offset + 2., offset + 4., offset + 4.),
@@ -80,8 +80,8 @@ fn benchmark_query(b: &mut Bencher) {
     for i in 0..100000 {
         let neg_y = if rng.gen::<bool>() { -1. } else { 1. };
         let neg_x = if rng.gen::<bool>() { -1. } else { 1. };
-        let offset_x = neg_x * rng.gen_range(9000., 10000.);
-        let offset_y = neg_y * rng.gen_range(9000., 10000.);
+        let offset_x = neg_x * rng.gen_range(9000.0..10000.0);
+        let offset_y = neg_y * rng.gen_range(9000.0..10000.0);
         tree.insert(Value::new(
             i,
             aabb2(offset_x + 2., offset_y + 2., offset_x + 4., offset_y + 4.),
@@ -92,10 +92,10 @@ fn benchmark_query(b: &mut Bencher) {
     let rays: Vec<Ray2<f32>> = (0..1000)
         .map(|_| {
             let p = Point2::new(
-                rng.gen_range(-10000., 10000.),
-                rng.gen_range(-10000., 10000.),
+                rng.gen_range(-10000.0..10000.0),
+                rng.gen_range(-10000.0..10000.0),
             );
-            let d = Vector2::new(rng.gen_range(-1., 1.), rng.gen_range(-1., 1.)).normalize();
+            let d = Vector2::new(rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0)).normalize();
             Ray2::new(p, d)
         })
         .collect();
@@ -119,8 +119,8 @@ fn benchmark_ray_closest_query(b: &mut Bencher) {
     for i in 0..100000 {
         let neg_y = if rng.gen::<bool>() { -1. } else { 1. };
         let neg_x = if rng.gen::<bool>() { -1. } else { 1. };
-        let offset_x = neg_x * rng.gen_range(9000., 10000.);
-        let offset_y = neg_y * rng.gen_range(9000., 10000.);
+        let offset_x = neg_x * rng.gen_range(9000.0..10000.0);
+        let offset_y = neg_y * rng.gen_range(9000.0..10000.0);
         tree.insert(Value::new(
             i,
             aabb2(offset_x + 2., offset_y + 2., offset_x + 4., offset_y + 4.),
@@ -131,10 +131,10 @@ fn benchmark_ray_closest_query(b: &mut Bencher) {
     let rays: Vec<Ray2<f32>> = (0..1000)
         .map(|_| {
             let p = Point2::new(
-                rng.gen_range(-10000., 10000.),
-                rng.gen_range(-10000., 10000.),
+                rng.gen_range(-10000.0..10000.0),
+                rng.gen_range(-10000.0..10000.0),
             );
-            let d = Vector2::new(rng.gen_range(-1., 1.), rng.gen_range(-1., 1.)).normalize();
+            let d = Vector2::new(rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0)).normalize();
             Ray2::new(p, d)
         })
         .collect();

--- a/benches/polyhedron.rs
+++ b/benches/polyhedron.rs
@@ -82,9 +82,9 @@ fn dirs(n: usize) -> Vec<Vector3<f32>> {
     (0..n)
         .map(|_| {
             Vector3::new(
-                rng.gen_range(-1., 1.),
-                rng.gen_range(-1., 1.),
-                rng.gen_range(-1., 1.),
+                rng.gen_range(-1.0..1.0),
+                rng.gen_range(-1.0..1.0),
+                rng.gen_range(-1.0..1.0),
             )
         })
         .collect::<Vec<_>>()

--- a/src/algorithm/minkowski/gjk/mod.rs
+++ b/src/algorithm/minkowski/gjk/mod.rs
@@ -9,6 +9,7 @@ use std::ops::{Neg, Range};
 use cgmath::BaseFloat;
 use cgmath::prelude::*;
 use cgmath::num_traits::NumCast;
+use cgmath::UlpsEq;
 
 use self::simplex::{Simplex, SimplexProcessor2, SimplexProcessor3};
 use crate::{CollisionStrategy, Contact};
@@ -109,7 +110,7 @@ where
         PL: Primitive<Point = P>,
         PR: Primitive<Point = P>,
         SP: SimplexProcessor<Point = P>,
-        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S>,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S> + UlpsEq,
         TL: Transform<P>,
         TR: Transform<P>,
     {
@@ -277,7 +278,7 @@ where
         PL: Primitive<Point = P>,
         PR: Primitive<Point = P>,
         SP: SimplexProcessor<Point = P>,
-        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S>,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S> + UlpsEq,
         TL: Transform<P>,
         TR: Transform<P>,
     {
@@ -365,7 +366,7 @@ where
     ) -> Option<Contact<P>>
     where
         P: EuclideanSpace<Scalar = S>,
-        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S>,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S> + UlpsEq,
         PL: Primitive<Point = P>,
         PR: Primitive<Point = P>,
         TL: Transform<P>,
@@ -415,7 +416,7 @@ where
     ) -> Option<Contact<P>>
     where
         P: EuclideanSpace<Scalar = S>,
-        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S>,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S> + UlpsEq,
         PL: Primitive<Point = P>,
         PR: Primitive<Point = P>,
         TL: Transform<P>,
@@ -479,7 +480,7 @@ where
     ) -> Option<S>
     where
         P: EuclideanSpace<Scalar = S>,
-        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S>,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace + Zero + Array<Element = S> + UlpsEq,
         PL: Primitive<Point = P>,
         PR: Primitive<Point = P>,
         TL: Transform<P>,

--- a/src/dbvt/mod.rs
+++ b/src/dbvt/mod.rs
@@ -900,7 +900,7 @@ where
 
         // Only do rotations occasionally, as they are fairly expensive, and shouldn't be overused.
         // For most scenarios, the majority of shapes will not have moved, so this is fine.
-        if rand::thread_rng().gen_range(0, 100) < PERFORM_ROTATION_PERCENTAGE {
+        if rand::thread_rng().gen_range(0..100) < PERFORM_ROTATION_PERCENTAGE {
             self.rotate(node_index);
         }
     }

--- a/tests/bound.rs
+++ b/tests/bound.rs
@@ -2,7 +2,7 @@ extern crate collision;
 
 use collision::PlaneBound;
 
-fn _box(_: Box<PlaneBound<f32>>) {}
+fn _box(_: Box<dyn PlaneBound<f32>>) {}
 
 #[test]
 fn bound_box() {}

--- a/tests/dbvt.rs
+++ b/tests/dbvt.rs
@@ -122,7 +122,7 @@ fn test_add_20() {
     let mut tree = DynamicBoundingVolumeTree::<Value2>::new();
     let mut rng = rand::thread_rng();
     for i in 0..20 {
-        let offset = rng.gen_range(-10., 10.);
+        let offset = rng.gen_range(-10.0..10.0);
         tree.insert(Value2::new(
             i,
             aabb2(offset + 0.1, offset + 0.1, offset + 0.3, offset + 0.3),


### PR DESCRIPTION
This updates all dependencies except for `approx` (which is updated to 0.4 but not 0.5) and `genmesh`, which would require more work to update.

Fixes #117, and makes this library compatible with cgmath 0.18.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/120)
<!-- Reviewable:end -->
