### PR TITLE
Custom Debug for Line and Ray

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -1,6 +1,8 @@
 //! Line segments
 
 use std::marker::PhantomData;
+use std::fmt;
+use std::fmt::Debug;
 
 use cgmath::prelude::*;
 use cgmath::{BaseFloat, BaseNum};
@@ -11,7 +13,7 @@ use crate::prelude::*;
 use crate::Ray2;
 
 /// A generic directed line segment from `origin` to `dest`.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate="serde_crate"))]
 pub struct Line<S, V, P> {
     /// Origin of the line
@@ -33,6 +35,13 @@ impl<S: BaseNum, V: VectorSpace<Scalar = S>, P: EuclideanSpace<Scalar = S, Diff 
             phantom_v: PhantomData,
             phantom_s: PhantomData,
         }
+    }
+}
+
+impl<S, V, P:Debug> Debug for Line<S,V,P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Line")?;
+        <[&P; 2] as fmt::Debug>::fmt(&[&self.origin, &self.dest], f)
     }
 }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,8 +1,7 @@
 //! Line segments
 
-use std::marker::PhantomData;
 use std::fmt;
-use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use cgmath::prelude::*;
 use cgmath::{BaseFloat, BaseNum};
@@ -38,10 +37,12 @@ impl<S: BaseNum, V: VectorSpace<Scalar = S>, P: EuclideanSpace<Scalar = S, Diff 
     }
 }
 
-impl<S, V, P:Debug> Debug for Line<S,V,P> {
+impl<S, V, P: fmt::Debug> fmt::Debug for Line<S, V, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Line")?;
-        <(&P, &P) as fmt::Debug>::fmt(&(&self.origin, &self.dest), f)
+        f.debug_tuple("Line")
+            .field(&self.origin)
+            .field(&self.dest)
+            .finish()
     }
 }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -41,7 +41,7 @@ impl<S: BaseNum, V: VectorSpace<Scalar = S>, P: EuclideanSpace<Scalar = S, Diff 
 impl<S, V, P:Debug> Debug for Line<S,V,P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Line")?;
-        <[&P; 2] as fmt::Debug>::fmt(&[&self.origin, &self.dest], f)
+        <(&P, &P) as fmt::Debug>::fmt(&(&self.origin, &self.dest), f)
     }
 }
 

--- a/src/primitive/primitive2.rs
+++ b/src/primitive/primitive2.rs
@@ -11,7 +11,7 @@ use crate::{Aabb2, Line2, Ray2};
 /// to use many different primitives in algorithms.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate="serde_crate"))]
-pub enum Primitive2<S> {
+pub enum Primitive2<S:cgmath::BaseNum> {
     /// Particle
     Particle(Particle2<S>),
     /// Line
@@ -26,37 +26,37 @@ pub enum Primitive2<S> {
     ConvexPolygon(ConvexPolygon<S>),
 }
 
-impl<S> From<Particle2<S>> for Primitive2<S> {
+impl<S:cgmath::BaseNum> From<Particle2<S>> for Primitive2<S> {
     fn from(particle: Particle2<S>) -> Primitive2<S> {
         Primitive2::Particle(particle)
     }
 }
 
-impl<S> From<Line2<S>> for Primitive2<S> {
+impl<S:cgmath::BaseNum> From<Line2<S>> for Primitive2<S> {
     fn from(line: Line2<S>) -> Primitive2<S> {
         Primitive2::Line(line)
     }
 }
 
-impl<S> From<Circle<S>> for Primitive2<S> {
+impl<S:cgmath::BaseNum> From<Circle<S>> for Primitive2<S> {
     fn from(circle: Circle<S>) -> Primitive2<S> {
         Primitive2::Circle(circle)
     }
 }
 
-impl<S> From<Rectangle<S>> for Primitive2<S> {
+impl<S:cgmath::BaseNum> From<Rectangle<S>> for Primitive2<S> {
     fn from(rectangle: Rectangle<S>) -> Primitive2<S> {
         Primitive2::Rectangle(rectangle)
     }
 }
 
-impl<S> From<Square<S>> for Primitive2<S> {
+impl<S:cgmath::BaseNum> From<Square<S>> for Primitive2<S> {
     fn from(rectangle: Square<S>) -> Primitive2<S> {
         Primitive2::Square(rectangle)
     }
 }
 
-impl<S> From<ConvexPolygon<S>> for Primitive2<S> {
+impl<S:cgmath::BaseNum> From<ConvexPolygon<S>> for Primitive2<S> {
     fn from(polygon: ConvexPolygon<S>) -> Primitive2<S> {
         Primitive2::ConvexPolygon(polygon)
     }

--- a/src/primitive/primitive2.rs
+++ b/src/primitive/primitive2.rs
@@ -26,37 +26,37 @@ pub enum Primitive2<S:cgmath::BaseNum> {
     ConvexPolygon(ConvexPolygon<S>),
 }
 
-impl<S:cgmath::BaseNum> From<Particle2<S>> for Primitive2<S> {
+impl<S: cgmath::BaseNum> From<Particle2<S>> for Primitive2<S> {
     fn from(particle: Particle2<S>) -> Primitive2<S> {
         Primitive2::Particle(particle)
     }
 }
 
-impl<S:cgmath::BaseNum> From<Line2<S>> for Primitive2<S> {
+impl<S: cgmath::BaseNum> From<Line2<S>> for Primitive2<S> {
     fn from(line: Line2<S>) -> Primitive2<S> {
         Primitive2::Line(line)
     }
 }
 
-impl<S:cgmath::BaseNum> From<Circle<S>> for Primitive2<S> {
+impl<S: cgmath::BaseNum> From<Circle<S>> for Primitive2<S> {
     fn from(circle: Circle<S>) -> Primitive2<S> {
         Primitive2::Circle(circle)
     }
 }
 
-impl<S:cgmath::BaseNum> From<Rectangle<S>> for Primitive2<S> {
+impl<S: cgmath::BaseNum> From<Rectangle<S>> for Primitive2<S> {
     fn from(rectangle: Rectangle<S>) -> Primitive2<S> {
         Primitive2::Rectangle(rectangle)
     }
 }
 
-impl<S:cgmath::BaseNum> From<Square<S>> for Primitive2<S> {
+impl<S: cgmath::BaseNum> From<Square<S>> for Primitive2<S> {
     fn from(rectangle: Square<S>) -> Primitive2<S> {
         Primitive2::Square(rectangle)
     }
 }
 
-impl<S:cgmath::BaseNum> From<ConvexPolygon<S>> for Primitive2<S> {
+impl<S: cgmath::BaseNum> From<ConvexPolygon<S>> for Primitive2<S> {
     fn from(polygon: ConvexPolygon<S>) -> Primitive2<S> {
         Primitive2::ConvexPolygon(polygon)
     }

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,8 +1,7 @@
 //! Generic rays
 
-use std::marker::PhantomData;
 use core::fmt;
-use core::fmt::Debug;
+use std::marker::PhantomData;
 
 use cgmath::prelude::*;
 use cgmath::{BaseFloat, BaseNum};
@@ -51,10 +50,12 @@ where
     }
 }
 
-impl<S, P:Debug, V:Debug> Debug for Ray<S,P,V> {
+impl<S, P: fmt::Debug, V: fmt::Debug> fmt::Debug for Ray<S, P, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Ray")?;
-        <(&P,&V) as fmt::Debug>::fmt(&(&self.origin, &self.direction), f)
+        f.debug_tuple("Ray")
+            .field(&self.origin)
+            .field(&self.direction)
+            .finish()
     }
 }
 

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,6 +1,8 @@
 //! Generic rays
 
 use std::marker::PhantomData;
+use core::fmt;
+use core::fmt::Debug;
 
 use cgmath::prelude::*;
 use cgmath::{BaseFloat, BaseNum};
@@ -11,7 +13,7 @@ use crate::traits::{Continuous, ContinuousTransformed, Discrete, DiscreteTransfo
 
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate="serde_crate"))]
 pub struct Ray<S, P, V> {
     /// Ray origin
@@ -46,6 +48,13 @@ where
             transform.transform_point(self.origin),
             transform.transform_vector(self.direction),
         )
+    }
+}
+
+impl<S, P:Debug, V:Debug> Debug for Ray<S,P,V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ray")?;
+        <(&P,&V) as fmt::Debug>::fmt(&(&self.origin, &self.direction), f)
     }
 }
 


### PR DESCRIPTION
I don't know why removing a `#derive(Debug)` from `Ray` and `Line` suddenly requires `S` in `Primitive2` to be `cgmath::BaseNum`, but it won't compile without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/collision-rs/134)
<!-- Reviewable:end -->
